### PR TITLE
Modified the package name and initial version in order to npm publish…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "edition-node-gulp",
+  "name": "patternfly-css",
   "description": "The gulp wrapper around patternlab-node core, providing tasks to interact with the core library and move supporting frontend assets.",
-  "version": "1.3.2",
+  "version": "0.0.1",
   "dependencies": {
     "browser-sync": "^2.0.0",
     "gulp": "gulpjs/gulp#4.0",


### PR DESCRIPTION
Modified the package name and initial version in order to npm publish. This will allow the webcomponent repos to begin working with the atomic repo.

@bleathem @andresgalante Please let me know if we want to use a different package name.