### PR TITLE
Implements main and filter toolbars

### DIFF
--- a/source/_data/listitems.json
+++ b/source/_data/listitems.json
@@ -70,7 +70,8 @@
       "long": "20",
       "short": "20"
     },
-    "seconds": "31"
+    "seconds": "31",
+    "word": "alpha"
   },
   "2": {
     "title": "Veggies sunt bona vobis, proinde vos postulo",
@@ -143,7 +144,8 @@
       "long": "20",
       "short": "20"
     },
-    "seconds": "31"
+    "seconds": "31",
+    "word": "bravo"
   },
   "3": {
     "title": "Bacon ipsum dolor sit amet turducken strip steak beef ribs shank",
@@ -216,7 +218,8 @@
       "long": "45",
       "short": "45"
     },
-    "seconds": "11"
+    "seconds": "11",
+    "word": "charlie"
   },
   "4": {
     "title": "Whatever swag accusamus occupy, gentrify butcher tote bag",
@@ -289,7 +292,8 @@
       "long": "14",
       "short": "14"
     },
-    "seconds": "52"
+    "seconds": "52",
+    "word": "delta"
   },
   "5": {
     "title": "Marshall McLuhan Colbert bump backpack journalist vast wasteland Romenesko CPM",
@@ -362,7 +366,8 @@
       "long": "37",
       "short": "37"
     },
-    "seconds": "24"
+    "seconds": "24",
+    "word": "echo"
   },
   "6": {
     "title": "Thunder, thunder, thundercats, Ho!",
@@ -435,7 +440,8 @@
       "long": "37",
       "short": "37"
     },
-    "seconds": "33"
+    "seconds": "33",
+    "word": "foxtrot"
   },
   "7": {
     "title": "Yeah, I like animals better than people sometimes",
@@ -508,7 +514,8 @@
       "long": "12",
       "short": "12"
     },
-    "seconds": "47"
+    "seconds": "47",
+    "word": "golf"
   },
   "8": {
     "title": "Webtwo ipsum dolor sit amet, eskobo chumby doostang bebo",
@@ -581,7 +588,8 @@
       "long": "42",
       "short": "42"
     },
-    "seconds": "21"
+    "seconds": "21",
+    "word": "hotel"
   },
   "9": {
     "title": "Rebel Mission to Ord Mantell",
@@ -654,7 +662,8 @@
       "long": "04",
       "short": "4"
     },
-    "seconds": "37"
+    "seconds": "37",
+    "word": "india"
   },
   "10": {
     "title": "Help, help, I'm being repressed!",
@@ -727,7 +736,8 @@
       "long": "51",
       "short": "51"
     },
-    "second": "19"
+    "second": "19",
+    "word": "juliett"
   },
   "11": {
     "title": "Danish danish candy canes bonbon cheesecake danish marzipan",
@@ -800,7 +810,8 @@
       "long": "55",
       "short": "55"
     },
-    "seconds": "12"
+    "seconds": "12",
+    "word": "kilo"
   },
   "12": {
     "title": "Cottage cheese brie lancashire. Boursin when the cheese comes out.",
@@ -873,6 +884,7 @@
       "long": "34",
       "short": "34"
     },
-    "seconds": "56"
+    "seconds": "56",
+    "word": "lima"
   }
 }

--- a/source/_patterns/basics/10-tags/tag.hbs
+++ b/source/_patterns/basics/10-tags/tag.hbs
@@ -1,6 +1,6 @@
 <span class="tag {{ tagClass }}">
   {{ tagText }}
   {{#if tagDismissable }}
-    <a href="#"><span class="pficon pficon-close">X <!--TODO: use a close atom --></span></a>
+    <a class="tag__a" href="#"><span class="pficon pficon-close"></span></a>
   {{/if}}
 </span>

--- a/source/_patterns/components/filter-list/filter-list.hbs
+++ b/source/_patterns/components/filter-list/filter-list.hbs
@@ -1,4 +1,4 @@
-<ul class="list-inline" style="border: 1px solid green;">
+<ul class="list-inline">
   {{# listitems.five }}
     <li class="list-inline-item">
       {{> basics-tag tagText=word tagClass="tag-info" tagDismissable="true" }}

--- a/source/_patterns/components/filter-list/filter-list.hbs
+++ b/source/_patterns/components/filter-list/filter-list.hbs
@@ -1,0 +1,7 @@
+<ul class="list-inline" style="border: 1px solid green;">
+  {{# listitems.five }}
+    <li class="list-inline-item">
+      {{> basics-tag tagText=word tagClass="tag-info" tagDismissable="true" }}
+    </li>
+  {{/ listitems.five }}
+</ul>

--- a/source/_patterns/components/filter-list/filter-list.md
+++ b/source/_patterns/components/filter-list/filter-list.md
@@ -1,0 +1,18 @@
+---
+title: Filter List
+---
+## Overview
+
+This is a list of dismissable tags used as filters. It is commonly used within a toolbar to show filters being applied.
+
+An example can be seen within the [toolbar pattern](http://www.patternfly.org/pattern-library/forms-and-controls/toolbar/#_design)
+
+## Accessibility
+
+Accessibility comes from the child elements.
+
+## Usage
+
+| Class | Usage |
+| -- | -- |
+| None |   |

--- a/source/_patterns/components/toolbar/filter-toolbar.hbs
+++ b/source/_patterns/components/toolbar/filter-toolbar.hbs
@@ -1,0 +1,28 @@
+<div class="row pf-toolbar">
+  <div class="pf-toolbar__group">
+      <h5>40 Results</h5>
+      <p>Active filters:</p>
+      {{> components-filter-list }}
+
+
+      <p><a href="#">Clear All Filters</a></p>
+  </div><!-- pf-toolbar__group -->
+
+    <div class="pf-toolbar__group">
+      <h5>40 Results</h5>
+      <p>Active filters:</p>
+      {{> components-filter-list }}
+
+      <ul class="list-inline" style="border:1px solid red;">
+        {{# listitems.five }}
+          <li class="list-inline-item">
+            {{> basics-tag tagText=word tagClass="tag-info" tagDismissable="true" }}
+          </li>
+        {{/ listitems.five }}
+      </ul>
+
+      <p><a href="#">Clear All Filters</a></p>
+    </div><!-- pf-toolbar__right -->
+
+  </div><!-- /col -->
+</div><!-- /row -->

--- a/source/_patterns/components/toolbar/filter-toolbar.hbs
+++ b/source/_patterns/components/toolbar/filter-toolbar.hbs
@@ -1,19 +1,19 @@
 <div class="row pf-toolbar">
   <div class="pf-toolbar__group">
-      <h5>40 Results</h5>
-      <p>Active filters:</p>
+      <h5 class="pf-toolbar__subgroup__item">40 Results</h5>
+      <p class="pf-toolbar__subgroup__item">Active filters:
 
 {{!-- IMPORTANT NOTE: This is a copy of filter-list.hbs as a temporary workaround. When a handlebars helper is created as a solution to using listitems, this should be replaced with the following: --}}
 {{!-- {{> components-filter-list }} --}}
-      <ul class="list-inline" style="border:1px solid red;">
-        {{# listitems.five }}
-          <li class="list-inline-item">
-            {{> basics-tag tagText=word tagClass="tag-info" tagDismissable="true" }}
-          </li>
-        {{/ listitems.five }}
+        <ul class="list-inline">
+          {{# listitems.five }}
+            <li class="list-inline-item">
+              {{> basics-tag tagText=word tagClass="tag-info" tagDismissable="true" }}
+            </li>
+          {{/ listitems.five }}
       </ul>
-
-      <p><a href="#">Clear All Filters</a></p>
+      </p>
+      <p class="pf-toolbar__subgroup__item"><a href="#">Clear All Filters</a></p>
     </div><!-- pf-toolbar__right -->
 
   </div><!-- /col -->

--- a/source/_patterns/components/toolbar/filter-toolbar.hbs
+++ b/source/_patterns/components/toolbar/filter-toolbar.hbs
@@ -2,17 +2,9 @@
   <div class="pf-toolbar__group">
       <h5>40 Results</h5>
       <p>Active filters:</p>
-      {{> components-filter-list }}
 
-
-      <p><a href="#">Clear All Filters</a></p>
-  </div><!-- pf-toolbar__group -->
-
-    <div class="pf-toolbar__group">
-      <h5>40 Results</h5>
-      <p>Active filters:</p>
-      {{> components-filter-list }}
-
+{{!-- IMPORTANT NOTE: This is a copy of filter-list.hbs as a temporary workaround. When a handlebars helper is created as a solution to using listitems, this should be replaced with the following: --}}
+{{!-- {{> components-filter-list }} --}}
       <ul class="list-inline" style="border:1px solid red;">
         {{# listitems.five }}
           <li class="list-inline-item">

--- a/source/_patterns/components/toolbar/main-toolbar.hbs
+++ b/source/_patterns/components/toolbar/main-toolbar.hbs
@@ -1,0 +1,14 @@
+<div class="row pf-toolbar">
+    <div class="pf-toolbar__group">
+      <span>{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}{{> basics-input}}
+</span>
+      <span>{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}
+</span>
+      <span>buttons</span>
+    </div>
+
+    <div class="pf-toolbar__group">
+      {{> basics-icon-button btnText="" btnClass="btn-link" iconFamily="fa" iconName="fa-search" iconModifier="" ariaLabeledBy="Search"}}
+      {{> components-view-selector }}
+    </div>
+</div><!-- /row -->

--- a/source/_patterns/components/toolbar/main-toolbar.hbs
+++ b/source/_patterns/components/toolbar/main-toolbar.hbs
@@ -1,14 +1,16 @@
 <div class="row pf-toolbar">
-    <div class="pf-toolbar__group">
-      <span>{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}{{> basics-input}}
-</span>
-      <span>{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}
-</span>
-      <span>buttons</span>
-    </div>
+    <ul class="list-inline pf-toolbar__group">
+      <div class="pf-toolbar__group__item"><!-- this dropdown needs to be inline -->{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}{{> basics-input}}</div>
+      <div class="pf-toolbar__group__item">{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}</div>
+      <div class="pf-toolbar__group__item">buttons</div>
+    </ul>
 
     <div class="pf-toolbar__group">
-      {{> basics-icon-button btnText="" btnClass="btn-link" iconFamily="fa" iconName="fa-search" iconModifier="" ariaLabeledBy="Search"}}
-      {{> components-view-selector }}
+      <div class="pf-toolbar__group__item">
+        {{> basics-icon-button btnText="" btnClass="btn-link" iconFamily="fa" iconName="fa-search" iconModifier="" ariaLabeledBy="Search"}}
+      </div>
+      <div class="pf-toolbar__group__item">
+        {{> components-view-selector }}
+      </div>
     </div>
 </div><!-- /row -->

--- a/source/_patterns/components/toolbar/main-toolbar.hbs
+++ b/source/_patterns/components/toolbar/main-toolbar.hbs
@@ -1,9 +1,19 @@
 <div class="row pf-toolbar">
-    <ul class="list-inline pf-toolbar__group">
-      <div class="pf-toolbar__group__item"><!-- this dropdown needs to be inline -->{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}{{> basics-input}}</div>
-      <div class="pf-toolbar__group__item">{{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}</div>
-      <div class="pf-toolbar__group__item">buttons</div>
-    </ul>
+    <div class="pf-toolbar__group form-inline">
+      <div class="pf-toolbar__group__item form-group">
+        {{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}
+        {{> basics-input}}
+      </div>
+      <div class="pf-toolbar__group__item form-group">
+        {{> basics-dropdown dropdownText= "Name" btnClass="btn-secondary" }}
+        {{> basics-icon-button btnText="" btnClass="btn-link" iconFamily="fa" iconName="fa-sort-alpha-asc" iconModifier="" ariaLabeledBy="Ascending Alphabetical Sort"}}
+      </div>
+      <div class="pf-toolbar__group__item form-group">
+        {{> basics-button btnText="Action" btnClass="btn-secondary" }}
+        {{> basics-button btnText="Action" btnClass="btn-secondary" }}
+        {{> basics-icon-button btnText="" btnClass="btn-link" iconFamily="fa" iconName="fa-ellipsis-v" iconModifier="" ariaLabeledBy="Kebab"}}
+      </div>
+    </div>
 
     <div class="pf-toolbar__group">
       <div class="pf-toolbar__group__item">

--- a/source/scss/_pf-basic-tags.scss
+++ b/source/scss/_pf-basic-tags.scss
@@ -12,3 +12,7 @@
     font-size: $font-size-relative-xs;
   }
 }
+
+.tag__a {
+  color: $color-pf-white;
+}

--- a/source/scss/_pf-component-toolbar.scss
+++ b/source/scss/_pf-component-toolbar.scss
@@ -1,0 +1,14 @@
+.pf-toolbar {
+  display: flex;
+  justify-content: space-between;
+  padding-right: ($grid-gutter-width-base / 2);
+  padding-left: ($grid-gutter-width-base / 2);
+  border: 1px solid red;
+}
+
+// This is a grouping of items in a toolbar
+.pf-toolbar__group {
+  border: 1px solid blue;
+  padding: .25em;
+  display:inline-block;
+}

--- a/source/scss/_pf-component-toolbar.scss
+++ b/source/scss/_pf-component-toolbar.scss
@@ -8,7 +8,17 @@
 
 // This is a grouping of items in a toolbar
 .pf-toolbar__group {
+  align-items: baseline;
   border: 1px solid blue;
   padding: .25em;
-  display:inline-block;
+  display:inline-flex;
+}
+
+.pf-toolbar__group__item {
+  display: inline-block;
+  border-right: 1px solid green;
+  margin-right: $pf-spacer-xxs;
+  &:last-child {
+    border-right: none;
+  }
 }

--- a/source/scss/_pf-component-toolbar.scss
+++ b/source/scss/_pf-component-toolbar.scss
@@ -3,22 +3,24 @@
   justify-content: space-between;
   padding-right: ($grid-gutter-width-base / 2);
   padding-left: ($grid-gutter-width-base / 2);
-  border: 1px solid red;
 }
 
 // This is a grouping of items in a toolbar
 .pf-toolbar__group {
   align-items: baseline;
-  border: 1px solid blue;
-  padding: .25em;
   display:inline-flex;
 }
 
 .pf-toolbar__group__item {
   display: inline-block;
-  border-right: 1px solid green;
-  margin-right: $pf-spacer-xxs;
-  &:last-child {
-    border-right: none;
-  }
+  padding: 0 $pf-spacer-xs;
+}
+
+.pf-toolbar__subgroup__item {
+  display: inline-block;
+  padding: 0 $pf-spacer-xs;
+}
+
+.pf-toolbar__group__item + .pf-toolbar__group__item {
+  border-left: 1px solid $color-pf-black-900;
 }

--- a/source/scss/_pf-shame.scss
+++ b/source/scss/_pf-shame.scss
@@ -1,4 +1,9 @@
 /*!
  * Patternfly Shame
- * The nest fot all our shamefull code.
+ * The nest for all our shameful code.
  */
+
+// When creating the toolbar, this is the only way I can get the dropdown and button to be on the same line. (Sarah)
+.form-inline .form-group .dropdown {
+  display: inline-block;
+}

--- a/source/scss/patternfly.scss
+++ b/source/scss/patternfly.scss
@@ -27,6 +27,7 @@
 @import "node_modules/bootstrap/scss/list-group";
 @import "node_modules/bootstrap/scss/responsive-embed";
 @import "node_modules/bootstrap/scss/close";
+@import "pf-component-toolbar";
 @import "pf-component-view-selector";
 @import "pf-shame";
 


### PR DESCRIPTION
This is a "good enough to demo" version but there are some spacing issues and philosophical questions to work out :-)
One philosophical question: many of the Bootstrap classes have margins built in...which violates our premise that each element fills its own space but will be separated from other elements by its container.
Also, this includes an element filter-list, which is a group of dismissable tags meant as a list of filters. There is a problem with including a pattern that uses listitems in another pattern. Brian is working on a handlebars solution but for now I've put in a workaround where the pattern is repeated in the place it should be referenced.