### PR TITLE
Consumed the patternlab-node plugin for the listitems handlebar-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "gulp": "gulpjs/gulp#4.0",
     "minimist": "^1.2.0",
     "patternengine-node-handlebars": "^1.0.0",
-    "pf-patternlab-node": "2.6.0-alpha-patternfly.1",
+    "pf-patternlab-node": "2.6.0-alpha-patternfly.2",
+    "plugin-node-handlebars-helper-listitems": "0.0.2",
     "styleguidekit-assets-default": "^3.0.0",
     "styleguidekit-mustache-default": "^3.0.0"
   },

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -1,39 +1,44 @@
 {
-  "paths" : {
-    "source" : {
+  "paths": {
+    "source": {
       "root": "./source/",
-      "patterns" : "./source/_patterns/",
-      "data" : "./source/_data/",
+      "patterns": "./source/_patterns/",
+      "data": "./source/_data/",
       "meta": "./source/_meta/",
-      "annotations" : "./source/_annotations/",
-      "styleguide" : "./node_modules/styleguidekit-assets-default/dist/",
-      "patternlabFiles" : "./node_modules/styleguidekit-mustache-default/views/",
-      "js" : "./source/js",
-      "images" : "./source/images",
-      "fonts" : "./source/fonts",
-      "css" : "./source/css/",
-      "scss" : "./source/scss/"
+      "annotations": "./source/_annotations/",
+      "styleguide": "./node_modules/styleguidekit-assets-default/dist/",
+      "patternlabFiles": "./node_modules/styleguidekit-mustache-default/views/",
+      "js": "./source/js",
+      "images": "./source/images",
+      "fonts": "./source/fonts",
+      "css": "./source/css/",
+      "scss": "./source/scss/"
     },
-    "public" : {
-      "root" : "./public/",
-      "patterns" : "./public/patterns/",
-      "data" : "./public/styleguide/data/",
-      "annotations" : "./public/annotations/",
-      "styleguide" : "./public/styleguide/",
-      "js" : "./public/js",
-      "images" : "./public/images",
-      "fonts" : "./public/fonts",
-      "css" : "./public/css"
+    "public": {
+      "root": "./public/",
+      "patterns": "./public/patterns/",
+      "data": "./public/styleguide/data/",
+      "annotations": "./public/annotations/",
+      "styleguide": "./public/styleguide/",
+      "js": "./public/js",
+      "images": "./public/images",
+      "fonts": "./public/fonts",
+      "css": "./public/css"
     }
   },
-  "styleGuideExcludes": [
-  ],
+  "styleGuideExcludes": [],
   "defaultPattern": "all",
   "defaultShowPatternInfo": false,
-  "cleanPublic" : true,
+  "cleanPublic": true,
   "patternExtension": "mustache",
-  "ignored-extensions" : ["scss", "DS_Store", "less"],
-  "ignored-directories" : ["scss"],
+  "ignored-extensions": [
+    "scss",
+    "DS_Store",
+    "less"
+  ],
+  "ignored-directories": [
+    "scss"
+  ],
   "debug": false,
   "ishControlsHide": {
     "s": false,
@@ -54,9 +59,12 @@
   },
   "ishMinimum": "240",
   "ishMaximum": "2600",
-  "patternStateCascade": ["inprogress", "inreview", "complete"],
-  "patternStates": {
-  },
+  "patternStateCascade": [
+    "inprogress",
+    "inreview",
+    "complete"
+  ],
+  "patternStates": {},
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,
@@ -66,5 +74,11 @@
     "rawTemplate": "",
     "markupOnly": ".markup-only"
   },
-  "cleanOutputHtml": true
+  "cleanOutputHtml": true,
+  "plugins": {
+    "plugin-node-handlebars-helper-listitems": {
+      "enabled": true
+    }
+  },
+  "plugin-node-handlebars-helper-listitems": false
 }

--- a/source/_patterns/basics/zexample/listitems.hbs
+++ b/source/_patterns/basics/zexample/listitems.hbs
@@ -1,0 +1,5 @@
+<ul>
+{{#listitems size=5}}
+  <li>Name: {{name.first}} {{name.last}}</li>
+{{/listitems}}
+</ul>


### PR DESCRIPTION
I provided a sample pattern showing the `{{#listitems}}` handlebars helper syntax.  It can be removed once a pattern is in place that consumes the helper.