### PR TITLE
Implements navigation tabs

### DIFF
--- a/source/_patterns/basics/tabs/tabs-variations.hbs
+++ b/source/_patterns/basics/tabs/tabs-variations.hbs
@@ -27,3 +27,11 @@ Single level with persistent secondary level and dropdown open
 {{> basics-tabs secondaryLevel="true" secondaryDropdown="true" secondaryDropdownActive="true"}}
 <br/>
 <br/>
+Patternfly style single level
+{{> basics-tabs pfTabsAsPrimary="true"}}
+<br/>
+<br/>
+Patternfly style single level with dropdown open
+{{> basics-tabs pfTabsAsPrimary="true"  dropdown="true" dropdownActive="true"}}
+<br/>
+<br/>

--- a/source/_patterns/basics/tabs/tabs-variations.hbs
+++ b/source/_patterns/basics/tabs/tabs-variations.hbs
@@ -1,0 +1,29 @@
+Single level
+{{> basics-tabs }}
+<br/>
+<br/>
+
+Single Level with dropdown
+{{> basics-tabs dropdown="true"}}
+<br/>
+<br/>
+
+Single Level with dropdown open
+{{> basics-tabs dropdown="true" dropdownActive="true"}}
+<br/>
+<br/>
+
+Single level with persistent secondary level
+{{> basics-tabs secondaryLevel="true"}}
+<br/>
+<br/>
+
+Single level with persistent secondary level and dropdown
+{{> basics-tabs secondaryLevel="true" secondaryDropdown="true"}}
+<br/>
+<br/>
+
+Single level with persistent secondary level and dropdown open
+{{> basics-tabs secondaryLevel="true" secondaryDropdown="true" secondaryDropdownActive="true"}}
+<br/>
+<br/>

--- a/source/_patterns/basics/tabs/tabs.hbs
+++ b/source/_patterns/basics/tabs/tabs.hbs
@@ -1,0 +1,65 @@
+{{!--
+dropdown - adds a tab with a dropdown
+dropdownActive - shows the dropdown tab menu open if true
+secondaryLevel - adds a secondary level menu
+secondaryDropdown - adds a dropdown tab to the secondary menu
+secondaryDropdownActive - shows the dropdown open if true
+ --}}
+
+<ul class="nav nav-tabs">
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link {{#unless dropdownActive }}active{{/unless }}">Tab One</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Two</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Three</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link disabled">Disabled</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Five</a></li>
+
+  {{#if dropdown }}
+    <li role="presentation" class="nav-item dropdown {{#if dropdownActive }}open{{/if }}">
+      <a class="nav-link dropdown-toggle active"
+        role="button"
+        aria-haspopup="true"
+        aria-expanded="true"
+        data-toggle="dropdown"
+        href="#">
+        Dropdown
+      </a>
+      <div class="dropdown-menu" role="menu">
+        <a class="dropdown-item">Action</a></a>
+        <a class="dropdown-item">Another action</a></a>
+        <a class="dropdown-item">Something else here</a></a>
+        <div class="dropdown-divider"></div>
+        <a class="dropdown-item">Separated link</a></a>
+      </div>
+    </li>
+  {{/if }}
+
+</ul>
+{{#if secondaryLevel }}
+<ul class="nav nav-tabs pf-nav-tabs">
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link {{#unless secondaryDropdownActive }}active{{/unless }}">Secondary Tab One</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Secondary Tab Two</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Secondary Tab Three</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link disabled">Secondary Disabled</a></li>
+  <li role="presentation" class="nav-item"><a href="#" class="nav-link">Secondary Tab Five</a></li>
+  {{#if secondaryDropdown }}
+    <li role="presentation" class="nav-item dropdown {{#if secondaryDropdownActive }}open{{/if }}">
+      <a class="nav-link dropdown-toggle {{#if secondaryDropdownActive}} active {{/if }}"
+        role="button"
+        aria-haspopup="true"
+        aria-expanded="true"
+        data-toggle="dropdown"
+        href="#">
+        Secondary Menu Dropdown
+      </a>
+      <div class="dropdown-menu" role="menu">
+        <a class="dropdown-item">Action</a></a>
+        <a class="dropdown-item">Another action</a></a>
+        <a class="dropdown-item">Something else here</a></a>
+        <div class="dropdown-divider"></div>
+        <a class="dropdown-item">Separated link</a></a>
+      </div>
+    </li>
+  {{/if }}
+
+</ul>
+{{/if }}

--- a/source/_patterns/basics/tabs/tabs.hbs
+++ b/source/_patterns/basics/tabs/tabs.hbs
@@ -4,9 +4,9 @@ dropdownActive - shows the dropdown tab menu open if true
 secondaryLevel - adds a secondary level menu
 secondaryDropdown - adds a dropdown tab to the secondary menu
 secondaryDropdownActive - shows the dropdown open if true
- --}}
+--}}
 
-<ul class="nav nav-tabs">
+<ul class="nav nav-tabs {{#if pfTabsAsPrimary }}pf-nav-tabs{{/if }}">
   <li role="presentation" class="nav-item"><a href="#" class="nav-link {{#unless dropdownActive }}active{{/unless }}">Tab One</a></li>
   <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Two</a></li>
   <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Three</a></li>
@@ -14,24 +14,24 @@ secondaryDropdownActive - shows the dropdown open if true
   <li role="presentation" class="nav-item"><a href="#" class="nav-link">Tab Five</a></li>
 
   {{#if dropdown }}
-    <li role="presentation" class="nav-item dropdown {{#if dropdownActive }}open{{/if }}">
-      <a class="nav-link dropdown-toggle active"
-        role="button"
-        aria-haspopup="true"
-        aria-expanded="true"
-        data-toggle="dropdown"
-        href="#">
-        Dropdown
-      </a>
-      <div class="dropdown-menu" role="menu">
-        <a class="dropdown-item">Action</a></a>
-        <a class="dropdown-item">Another action</a></a>
-        <a class="dropdown-item">Something else here</a></a>
-        <div class="dropdown-divider"></div>
-        <a class="dropdown-item">Separated link</a></a>
-      </div>
-    </li>
-  {{/if }}
+  <li role="presentation" class="nav-item dropdown {{#if dropdownActive }}open{{/if }}">
+    <a class="nav-link dropdown-toggle active"
+    role="button"
+    aria-haspopup="true"
+    aria-expanded="true"
+    data-toggle="dropdown"
+    href="#">
+    Dropdown
+  </a>
+  <div class="dropdown-menu" role="menu">
+    <a class="dropdown-item">Action</a></a>
+    <a class="dropdown-item">Another action</a></a>
+    <a class="dropdown-item">Something else here</a></a>
+    <div class="dropdown-divider"></div>
+    <a class="dropdown-item">Separated link</a></a>
+  </div>
+</li>
+{{/if }}
 
 </ul>
 {{#if secondaryLevel }}
@@ -42,24 +42,24 @@ secondaryDropdownActive - shows the dropdown open if true
   <li role="presentation" class="nav-item"><a href="#" class="nav-link disabled">Secondary Disabled</a></li>
   <li role="presentation" class="nav-item"><a href="#" class="nav-link">Secondary Tab Five</a></li>
   {{#if secondaryDropdown }}
-    <li role="presentation" class="nav-item dropdown {{#if secondaryDropdownActive }}open{{/if }}">
-      <a class="nav-link dropdown-toggle {{#if secondaryDropdownActive}} active {{/if }}"
-        role="button"
-        aria-haspopup="true"
-        aria-expanded="true"
-        data-toggle="dropdown"
-        href="#">
-        Secondary Menu Dropdown
-      </a>
-      <div class="dropdown-menu" role="menu">
-        <a class="dropdown-item">Action</a></a>
-        <a class="dropdown-item">Another action</a></a>
-        <a class="dropdown-item">Something else here</a></a>
-        <div class="dropdown-divider"></div>
-        <a class="dropdown-item">Separated link</a></a>
-      </div>
-    </li>
-  {{/if }}
+  <li role="presentation" class="nav-item dropdown {{#if secondaryDropdownActive }}open{{/if }}">
+    <a class="nav-link dropdown-toggle {{#if secondaryDropdownActive}} active {{/if }}"
+    role="button"
+    aria-haspopup="true"
+    aria-expanded="true"
+    data-toggle="dropdown"
+    href="#">
+    Secondary Menu Dropdown
+  </a>
+  <div class="dropdown-menu" role="menu">
+    <a class="dropdown-item">Action</a></a>
+    <a class="dropdown-item">Another action</a></a>
+    <a class="dropdown-item">Something else here</a></a>
+    <div class="dropdown-divider"></div>
+    <a class="dropdown-item">Separated link</a></a>
+  </div>
+</li>
+{{/if }}
 
 </ul>
 {{/if }}

--- a/source/_patterns/basics/tabs/tabs.md
+++ b/source/_patterns/basics/tabs/tabs.md
@@ -1,0 +1,15 @@
+---
+title: Tabs
+---
+## Overview
+
+See [Bootstrap tabs](http://v4-alpha.getbootstrap.com/components/navs/#tabs) for complete tabs documentation.
+
+## Accessibility
+
+
+## Usage
+
+| Class | Usage |
+| -- | -- |
+| `.pf-nav-tabs` **Applied to:** `ul` |  **Outcome:** Creates a secondary level menu **Required:** No **Remarks:** Always use it with `.nav` and `.nav-tabs`. |

--- a/source/css/patternfly.css
+++ b/source/css/patternfly.css
@@ -5553,7 +5553,7 @@ tbody.collapse.in {
   margin-left: 1rem; }
 
 .nav-tabs {
-  border-bottom: 1px solid #ddd; }
+  border-bottom: 1px solid #ededed; }
   .nav-tabs::after {
     content: "";
     display: table;
@@ -5568,7 +5568,7 @@ tbody.collapse.in {
     padding: 0.5em 1em;
     border: 1px solid transparent; }
     .nav-tabs .nav-link:focus, .nav-tabs .nav-link:hover {
-      border-color: #d1d1d1 #d1d1d1 #ddd; }
+      border-color: #ededed #ededed #ededed; }
     .nav-tabs .nav-link.disabled, .nav-tabs .nav-link.disabled:focus, .nav-tabs .nav-link.disabled:hover {
       color: #8b8d8f;
       background-color: transparent;
@@ -5577,7 +5577,7 @@ tbody.collapse.in {
   .nav-tabs .nav-item.open .nav-link,
   .nav-tabs .nav-item.open .nav-link:focus,
   .nav-tabs .nav-item.open .nav-link:hover {
-    color: #4d5258;
+    color: #0088ce;
     background-color: #fff;
     border-color: #ddd #ddd transparent; }
   .nav-tabs .dropdown-menu {
@@ -5617,6 +5617,40 @@ tbody.collapse.in {
 
 .tab-content > .active {
   display: block; }
+
+.nav-link {
+  color: #4d5258; }
+  .nav-link:focus, .nav-link:active, .nav-link:hover {
+    color: #4d5258; }
+
+.nav-tabs .nav-link {
+  padding: 0.25rem 1rem; }
+
+.nav-tabs .nav-item + .nav-item {
+  margin-left: 0; }
+
+.nav-tabs .dropdown-menu {
+  margin-top: 0;
+  border-top: 0; }
+
+.nav-tabs + .pf-nav-tabs .nav-link {
+  font-size: 0.875em; }
+
+.pf-nav-tabs .nav-link {
+  border-width: 0 0 2px 0;
+  border-color: transparent;
+  margin: 0.75rem 1rem 0;
+  padding: 0; }
+  .pf-nav-tabs .nav-link:focus, .pf-nav-tabs .nav-link:active, .pf-nav-tabs .nav-link:hover {
+    border-color: #ddd; }
+  .pf-nav-tabs .nav-link.active {
+    border-color: #0088ce; }
+    .pf-nav-tabs .nav-link.active:focus, .pf-nav-tabs .nav-link.active:active, .pf-nav-tabs .nav-link.active:hover {
+      border-color: #0088ce; }
+
+.pf-nav-tabs .dropdown-menu {
+  margin-left: 1rem;
+  margin-top: -1px; }
 
 .navbar {
   position: relative;

--- a/source/scss/_pf-basic-tabs.scss
+++ b/source/scss/_pf-basic-tabs.scss
@@ -3,7 +3,10 @@
 //
 
 .nav-link {
+  color: $pf-tabs-color;
+  @include hover-focus-active {
     color: $pf-tabs-color;
+  }
 }
 
 .nav-tabs {
@@ -25,28 +28,31 @@
 
 // Secondary tabs
 .pf-nav-tabs {
-
+  .nav-tabs + & {
+    .nav-link {
+      font-size: $font-size-relative-sm;
+    }
+  }
   .nav-link {
     border-width: 0 0 $nav-tabs-border-width*2 0;
     border-color: transparent;
-    font-size: $font-size-relative-sm;
     margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
     padding: 0;
 
     @include hover-focus-active {
-     border-color: $nav-tabs-active-link-hover-border-color;
+      border-color: $nav-tabs-active-link-hover-border-color;
     }
 
     &.active {
-     border-color: $nav-tabs-active-link-hover-color;
-    @include hover-focus-active {
       border-color: $nav-tabs-active-link-hover-color;
+      @include hover-focus-active {
+        border-color: $nav-tabs-active-link-hover-color;
+      }
     }
-   }
   }
 
   .dropdown-menu {
-   margin-left: $pf-spacer-sm;
-   margin-top: -$nav-tabs-border-width;
+    margin-left: $pf-spacer-sm;
+    margin-top: -$nav-tabs-border-width;
   }
 }

--- a/source/scss/_pf-basic-tabs.scss
+++ b/source/scss/_pf-basic-tabs.scss
@@ -1,0 +1,53 @@
+//
+// Tabs
+//
+
+.nav-link {
+    color: $pf-tabs-color;
+}
+
+.nav-tabs .nav-link {
+  padding: $pf-spacer-xxxs $pf-spacer-sm; // override bootstrap's spacing
+}
+
+// override bootstrap to make the tabs butt next to each other
+.nav-tabs .nav-item + .nav-item {
+  margin-left: 0;
+}
+
+// this adjusts the top of the dropdown to visually connect with the tab
+.nav-tabs .dropdown-menu {
+  margin-top: 0;
+  border-top: 0;
+}
+
+/////
+// $nav-tabs-active-link-hover-border-color
+// $nav-tabs-active-link-hover-bg
+// $nav-tabs-active-link-hover-color
+// $nav-tabs-border-width
+
+// Secondary tabs
+ .pf-nav-tabs .nav-link {
+   border-width: 0 0 $nav-tabs-border-width*2 0;
+   border-color: transparent;
+   font-size: $font-size-relative-sm;
+   margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
+   padding: 0;
+
+   @include hover-focus-active {
+     border-color: $nav-tabs-active-link-hover-border-color;
+   }
+
+   &.active {
+     border-color: $nav-tabs-active-link-hover-color;
+    @include hover-focus-active {
+      border-color: $nav-tabs-active-link-hover-color;
+    }
+
+   }
+ }
+ .pf-nav-tabs .dropdown-menu {
+   margin-left: $pf-spacer-sm;
+   margin-top: -$nav-tabs-border-width;
+ }

--- a/source/scss/_pf-basic-tabs.scss
+++ b/source/scss/_pf-basic-tabs.scss
@@ -6,48 +6,47 @@
     color: $pf-tabs-color;
 }
 
-.nav-tabs .nav-link {
-  padding: $pf-spacer-xxxs $pf-spacer-sm; // override bootstrap's spacing
-}
+.nav-tabs {
 
-// override bootstrap to make the tabs butt next to each other
-.nav-tabs .nav-item + .nav-item {
-  margin-left: 0;
+  // overrides bootstrap's spacing
+  .nav-link {
+    padding: $pf-spacer-xxxs $pf-spacer-sm;
+  }
+  // overrides bootstrap to make the tabs butt next to each other
+  .nav-item + .nav-item {
+    margin-left: 0;
+  }
+  // adjusts the top of the dropdown to visually connect with the tab
+  .dropdown-menu {
+    margin-top: 0;
+    border-top: 0;
+  }
 }
-
-// this adjusts the top of the dropdown to visually connect with the tab
-.nav-tabs .dropdown-menu {
-  margin-top: 0;
-  border-top: 0;
-}
-
-/////
-// $nav-tabs-active-link-hover-border-color
-// $nav-tabs-active-link-hover-bg
-// $nav-tabs-active-link-hover-color
-// $nav-tabs-border-width
 
 // Secondary tabs
- .pf-nav-tabs .nav-link {
-   border-width: 0 0 $nav-tabs-border-width*2 0;
-   border-color: transparent;
-   font-size: $font-size-relative-sm;
-   margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
-   padding: 0;
+.pf-nav-tabs {
 
-   @include hover-focus-active {
+  .nav-link {
+    border-width: 0 0 $nav-tabs-border-width*2 0;
+    border-color: transparent;
+    font-size: $font-size-relative-sm;
+    margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
+    padding: 0;
+
+    @include hover-focus-active {
      border-color: $nav-tabs-active-link-hover-border-color;
-   }
+    }
 
-   &.active {
+    &.active {
      border-color: $nav-tabs-active-link-hover-color;
     @include hover-focus-active {
       border-color: $nav-tabs-active-link-hover-color;
     }
-
    }
- }
- .pf-nav-tabs .dropdown-menu {
+  }
+
+  .dropdown-menu {
    margin-left: $pf-spacer-sm;
    margin-top: -$nav-tabs-border-width;
- }
+  }
+}

--- a/source/scss/_pf-basic-tabs.scss
+++ b/source/scss/_pf-basic-tabs.scss
@@ -15,8 +15,10 @@
     padding: $pf-spacer-xxxs $pf-spacer-sm;
   }
   // overrides bootstrap to make the tabs butt next to each other
-  .nav-item + .nav-item {
-    margin-left: 0;
+  .nav-item {
+    + .nav-item {
+      margin-left: 0;
+    }
   }
   // adjusts the top of the dropdown to visually connect with the tab
   .dropdown-menu {
@@ -57,5 +59,4 @@
       margin-left: $pf-spacer-sm;
     }
   }
-
 }

--- a/source/scss/_pf-basic-variables.scss
+++ b/source/scss/_pf-basic-variables.scss
@@ -134,6 +134,17 @@ $brand-danger:              $color-pf-red-100;
 $pf-bg-hover-color: $color-pf-blue-50;
 $pf-border-hover-color: $color-pf-blue-200;
 
+
+// Links
+//
+// Style anchor elements.
+
+$link-color:            $brand-primary;
+// $link-decoration:       none !default;
+// $link-hover-color:      darken($link-color, 15%) !default;
+// $link-hover-decoration: underline !default;
+
+
 // Font weight
 //
 
@@ -491,3 +502,19 @@ $state-danger-border:            $brand-danger;
 $alert-padding-x:             $spacer;
 $alert-link-font-weight:      normal;
 $pf-alert-icon-font-size:     $icon-size-sm;
+
+
+// Tabs
+//
+// Define tab colors, etc.
+
+$nav-tabs-border-color:                       $color-pf-black-200;
+// $nav-tabs-border-width:                       $border-width !default;
+// $nav-tabs-border-radius:                      $border-radius !default;
+$nav-tabs-link-hover-border-color:            $color-pf-black-200;
+$nav-tabs-active-link-hover-color:            $link-color;
+// $nav-tabs-active-link-hover-bg:               $body-bg !default;
+// $nav-tabs-active-link-hover-border-color:     #ddd !default;
+// $nav-tabs-justified-link-border-color:        $nav-tabs-border-color;
+// $nav-tabs-justified-active-link-border-color: $body-bg !default;
+$pf-tabs-color:                               $color-pf-black-700;

--- a/source/scss/patternfly.scss
+++ b/source/scss/patternfly.scss
@@ -12,6 +12,7 @@
 @import "node_modules/bootstrap/scss/input-group";
 @import "node_modules/bootstrap/scss/custom-forms";
 @import "node_modules/bootstrap/scss/nav";
+@import "pf-basic-tabs";
 @import "node_modules/bootstrap/scss/navbar";
 @import "node_modules/bootstrap/scss/card";
 @import "pf-component-card";


### PR DESCRIPTION
Adds navigation tabs, both bootstrap tabs and Patternfly-specific secondary level. Justified version has been omitted as it is currently not included in Bootstrap 4. (noted in [upgrade notes](https://docs.google.com/document/d/1tT-fg_WcjO2HpLO9KbDoY7Ks_uBmAdnnAtP8C-bgjWc/edit#heading=h.sqkjeb6zbrvl))

Demo here https://srambach.github.io/patternfly-atomic/?p=viewall-basics-tabs