### PR TITLE
Updates documentation for PTNFLY-2148

### DIFF
--- a/.github/DOCUMENTATION_TEMPLATE.md
+++ b/.github/DOCUMENTATION_TEMPLATE.md
@@ -1,0 +1,27 @@
+---
+title: pattern-name-here
+---
+## Overview
+
+If this is a bootstrap component:
+This is a Bootstrap component, [see complete documentation here](URL)
+
+Otherwise:
+
+Link to the design specs
+
+Only if needed write a short description with implementation notes. Design and interaction notes are already written on the design specs, don't repeat information.
+
+For example for buttons: Always add a modifier class to add color to the button. Never use the class `.btn` on its own.
+
+## Accessibility
+
+Write accessibility, aria tags, tab index and other notes to make this component accessible.
+
+## Usage
+
+| Class | Usage |
+| -- | -- |
+| `.class-name-here` **Applied to:** `<tags-here>` |  **Outcome:** Outcome-here **Required:** Yes/No **Remarks:** Remarks-here |
+| Example: `.btn` **Applied to:** `<a>`, `<button>` |  **Outcome:** Initiates a button **Required:** Yes **Remarks:** Always use it with a modifier class. |
+| `.btn-secondary` **Applied to:** `.btn` | **Outcome:** Adds secondary color **Required:** Yes |

--- a/source/_patterns/basics/forms/input.md
+++ b/source/_patterns/basics/forms/input.md
@@ -1,5 +1,5 @@
 ---
-title: Forms
+title: Forms Input
 ---
 ## Overview
 

--- a/source/_patterns/basics/forms/select.md
+++ b/source/_patterns/basics/forms/select.md
@@ -1,7 +1,7 @@
 ---
-title: Forms
+title: Forms Select
 ---
 ## Overview
 
 This is a Bootstrap component, [see complete documentation
-here](http://v4-alpha.getbootstrap.com/components/forms/)
+here](http://v4-alpha.getbootstrap.com/components/forms/#select-menu)

--- a/source/_patterns/basics/icons/icon-sizes.md
+++ b/source/_patterns/basics/icons/icon-sizes.md
@@ -1,5 +1,5 @@
 ---
-title: PatternFly Icon with Circle Decorator
+title: PatternFly Icon Sizes
 ---
 
 ## Overview

--- a/source/_patterns/basics/typography/inline-elements.md
+++ b/source/_patterns/basics/typography/inline-elements.md
@@ -1,0 +1,9 @@
+---
+title: Inline Elements
+---
+## Overview
+
+This is a Bootstrap component, [see complete documentation here](http://v4-alpha.getbootstrap.com/content/typography/#inline-text-elements)
+
+
+Patternfly design specs are at [https://www.patternfly.org/styles/typography/](https://www.patternfly.org/styles/typography/).

--- a/source/_patterns/basics/typography/lead.md
+++ b/source/_patterns/basics/typography/lead.md
@@ -1,0 +1,9 @@
+---
+title: Lead text
+---
+## Overview
+
+This is a Bootstrap component, [see complete documentation here](http://v4-alpha.getbootstrap.com/content/typography/#lead)
+
+
+Patternfly design specs are at [https://www.patternfly.org/styles/typography/](https://www.patternfly.org/styles/typography/).

--- a/source/_patterns/basics/typography/lists.md
+++ b/source/_patterns/basics/typography/lists.md
@@ -1,0 +1,9 @@
+---
+title: Lists
+---
+## Overview
+
+This is a Bootstrap component, [see complete documentation here](http://v4-alpha.getbootstrap.com/content/typography/#lists)
+
+
+Patternfly design specs are at [https://www.patternfly.org/styles/typography/](https://www.patternfly.org/styles/typography/).

--- a/source/_patterns/basics/typography/paragraph.md
+++ b/source/_patterns/basics/typography/paragraph.md
@@ -1,0 +1,9 @@
+---
+title: Paragraph
+---
+## Overview
+
+This is a basic HTML element.
+
+
+Patternfly design specs are at [https://www.patternfly.org/styles/typography/](https://www.patternfly.org/styles/typography/).

--- a/source/_patterns/components/badges/badge-styles.md
+++ b/source/_patterns/components/badges/badge-styles.md
@@ -1,0 +1,8 @@
+---
+title: Badges
+---
+## Overview
+
+This is a Bootstrap component, [see complete documentation here](http://v4-alpha.getbootstrap.com/components/badge/#contextual-variations)
+
+PatternFly design specs are at [http://www.patternfly.org/pattern-library/widgets/#labels](http://www.patternfly.org/pattern-library/widgets/#labels)

--- a/source/_patterns/components/cards/card-accent.md
+++ b/source/_patterns/components/cards/card-accent.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Accent
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-footer-dropdown.md
+++ b/source/_patterns/components/cards/card-footer-dropdown.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Dropdown in Footer
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-header-dropdown.md
+++ b/source/_patterns/components/cards/card-header-dropdown.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Dropdown in Header
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-header-kebab.md
+++ b/source/_patterns/components/cards/card-header-kebab.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card Header Kebab
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-icon-large.md
+++ b/source/_patterns/components/cards/card-icon-large.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with large icon
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-icon-medium.md
+++ b/source/_patterns/components/cards/card-icon-medium.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with medium icon
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-kebab.md
+++ b/source/_patterns/components/cards/card-kebab.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Kebab
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-multiselect-header.md
+++ b/source/_patterns/components/cards/card-multiselect-header.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Multiselect in Header
 ---
 ## Overview
 

--- a/source/_patterns/components/cards/card-multiselect.md
+++ b/source/_patterns/components/cards/card-multiselect.md
@@ -1,5 +1,5 @@
 ---
-title: Card
+title: Card with Multiselect
 ---
 ## Overview
 

--- a/source/_patterns/components/dropdowns/kebab.md
+++ b/source/_patterns/components/dropdowns/kebab.md
@@ -4,3 +4,7 @@ title: Kebab
 ## Overview
 
 The kebab is a variation of a dropdown where the dropdown button displays an ellipsis icon instead of text.
+
+| Class | Usage |
+| -- | -- |
+| `.pf-dropdown--kebab` **Applied to:** `.dropdown` |  **Outcome:** Adjusts the vertical alignment on a kebab menu in a card   **Required:** No **Remarks:** Refer to [Card Header Kebab](/?p=components-card-header-kebab)|

--- a/source/_patterns/components/tabs/tabs.md
+++ b/source/_patterns/components/tabs/tabs.md
@@ -12,4 +12,4 @@ See [Bootstrap tabs](http://v4-alpha.getbootstrap.com/components/navs/#tabs) for
 
 | Class | Usage |
 | -- | -- |
-| `.pf-nav-tabs` **Applied to:** `ul` |  **Outcome:** Displays the menu in Patternfly style rather than the default tabs **Required:** No **Remarks:** Always use it with `.nav` and `.nav-tabs`. |
+| `.pf-nav-tabs` **Applied to:** `ul` |  **Outcome:** Displays the menu in Patternfly secondary uderline style rather than the default square tab style **Required:** No **Remarks:** Always use it with `.nav` and `.nav-tabs`. |

--- a/source/_patterns/components/view-selector/view-selector.md
+++ b/source/_patterns/components/view-selector/view-selector.md
@@ -3,7 +3,7 @@ title: View Control
 ---
 ## Overview
 
-This element does not have its own design but can be seen in [toolbar pattern](http://www.patternfly.org/pattern-library/forms-and-controls/toolbar/#_design).
+This element does not have its own design but can be seen in the [toolbar pattern](http://www.patternfly.org/pattern-library/forms-and-controls/toolbar/#_design).
 
 Uses Bootstrap `.btn` and `.btn-link` classes to style buttons contained in the View Selector.
 


### PR DESCRIPTION
Adds the documentation template, links to it from the wiki, and applies the template to all patterns (except alerts, cards, and patterns that are variations on a base pattern).